### PR TITLE
Initial cms academic workstream commit

### DIFF
--- a/research-workstream/2023/1HC23/README.md
+++ b/research-workstream/2023/1HC23/README.md
@@ -1,0 +1,23 @@
+#Committing new content, reviewing, and browsing
+If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
+
+##Instructions for committing new content
+If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
+ - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
+ - Create a new branch 
+   - In the 'proposed' directory find your publication for review and create a folder with your name
+      - If the publication does not have a review folder, please create it using the title of the work. Use best judgement on length.
+   - Either add your .md review or create a markdown file and copy/paste your review into it. 
+   - upload any figures to be referenced by your markdown review in this folder as well. No ppt/word/etc. yet please, we don't have a git LFS set up at the moment. 
+ - Push branch to your local fork and issue a pull request to the main repo
+ - Select reviewers for your merge request
+ - Loop as needed until merge request accepted
+
+##Instructions for committing reviews
+
+Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
+
+If you're committing a new content review see above, if you have comments or additions to already submitted reviews please consider the following. If you have commentary on a review of a proposed work and it has not yet been merged, chime in on the merge request
+
+If the review was already merged into main, review the instructions for committing new content. In the reviewer's folder of a paper, add another markdown file with your comments and add your name to the title of the file. Follow the branch/merge instructions. 
+

--- a/research-workstream/2023/1HC23/README.md
+++ b/research-workstream/2023/1HC23/README.md
@@ -1,7 +1,7 @@
-#Committing new content, reviewing, and browsing
+# Committing new content, reviewing, and browsing
 If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
 
-##Instructions for committing new content
+## Instructions for committing new content
 If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
  - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
  - Create a new branch 
@@ -13,7 +13,7 @@ If this is an active review window, and you are committing a review of a propose
  - Select reviewers for your merge request
  - Loop as needed until merge request accepted
 
-##Instructions for committing reviews
+## Instructions for committing reviews
 
 Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
 

--- a/research-workstream/2023/2HC23/README.md
+++ b/research-workstream/2023/2HC23/README.md
@@ -1,0 +1,23 @@
+#Committing new content, reviewing, and browsing
+If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
+
+##Instructions for committing new content
+If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
+ - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
+ - Create a new branch 
+   - In the 'proposed' directory find your publication for review and create a folder with your name
+      - If the publication does not have a review folder, please create it using the title of the work. Use best judgement on length.
+   - Either add your .md review or create a markdown file and copy/paste your review into it. 
+   - upload any figures to be referenced by your markdown review in this folder as well. No ppt/word/etc. yet please, we don't have a git LFS set up at the moment. 
+ - Push branch to your local fork and issue a pull request to the main repo
+ - Select reviewers for your merge request
+ - Loop as needed until merge request accepted
+
+##Instructions for committing reviews
+
+Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
+
+If you're committing a new content review see above, if you have comments or additions to already submitted reviews please consider the following. If you have commentary on a review of a proposed work and it has not yet been merged, chime in on the merge request
+
+If the review was already merged into main, review the instructions for committing new content. In the reviewer's folder of a paper, add another markdown file with your comments and add your name to the title of the file. Follow the branch/merge instructions. 
+

--- a/research-workstream/2023/2HC23/README.md
+++ b/research-workstream/2023/2HC23/README.md
@@ -1,7 +1,7 @@
-#Committing new content, reviewing, and browsing
+# Committing new content, reviewing, and browsing
 If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
 
-##Instructions for committing new content
+## Instructions for committing new content
 If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
  - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
  - Create a new branch 
@@ -13,7 +13,7 @@ If this is an active review window, and you are committing a review of a propose
  - Select reviewers for your merge request
  - Loop as needed until merge request accepted
 
-##Instructions for committing reviews
+## Instructions for committing reviews
 
 Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
 

--- a/research-workstream/2023/README.md
+++ b/research-workstream/2023/README.md
@@ -1,0 +1,5 @@
+#How to navigate this directory tree
+
+Each year reflects the review work of the CMS research workstream. In each directory there are review windows (e.g. xHCyy for now, we seem to be on a bi-annual cadence). In each review window there are another two folders, one for the selected work for the review window and another for the papers reviewed. 
+
+

--- a/research-workstream/2023/README.md
+++ b/research-workstream/2023/README.md
@@ -1,4 +1,4 @@
-#How to navigate this directory tree
+# How to navigate this directory tree
 
 Each year reflects the review work of the CMS research workstream. In each directory there are review windows (e.g. xHCyy for now, we seem to be on a bi-annual cadence). In each review window there are another two folders, one for the selected work for the review window and another for the papers reviewed. 
 

--- a/research-workstream/2024/1HC24/README.md
+++ b/research-workstream/2024/1HC24/README.md
@@ -1,0 +1,23 @@
+#Committing new content, reviewing, and browsing
+If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
+
+##Instructions for committing new content
+If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
+ - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
+ - Create a new branch 
+   - In the 'proposed' directory find your publication for review and create a folder with your name
+      - If the publication does not have a review folder, please create it using the title of the work. Use best judgement on length.
+   - Either add your .md review or create a markdown file and copy/paste your review into it. 
+   - upload any figures to be referenced by your markdown review in this folder as well. No ppt/word/etc. yet please, we don't have a git LFS set up at the moment. 
+ - Push branch to your local fork and issue a pull request to the main repo
+ - Select reviewers for your merge request
+ - Loop as needed until merge request accepted
+
+##Instructions for committing reviews
+
+Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
+
+If you're committing a new content review see above, if you have comments or additions to already submitted reviews please consider the following. If you have commentary on a review of a proposed work and it has not yet been merged, chime in on the merge request
+
+If the review was already merged into main, review the instructions for committing new content. In the reviewer's folder of a paper, add another markdown file with your comments and add your name to the title of the file. Follow the branch/merge instructions. 
+

--- a/research-workstream/2024/1HC24/README.md
+++ b/research-workstream/2024/1HC24/README.md
@@ -1,7 +1,7 @@
-#Committing new content, reviewing, and browsing
+# Committing new content, reviewing, and browsing
 If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
 
-##Instructions for committing new content
+## Instructions for committing new content
 If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
  - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
  - Create a new branch 
@@ -13,7 +13,7 @@ If this is an active review window, and you are committing a review of a propose
  - Select reviewers for your merge request
  - Loop as needed until merge request accepted
 
-##Instructions for committing reviews
+## Instructions for committing reviews
 
 Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
 

--- a/research-workstream/2024/2HC24/README.md
+++ b/research-workstream/2024/2HC24/README.md
@@ -1,0 +1,23 @@
+#Committing new content, reviewing, and browsing
+If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
+
+##Instructions for committing new content
+If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
+ - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
+ - Create a new branch 
+   - In the 'proposed' directory find your publication for review and create a folder with your name
+      - If the publication does not have a review folder, please create it using the title of the work. Use best judgement on length.
+   - Either add your .md review or create a markdown file and copy/paste your review into it. 
+   - upload any figures to be referenced by your markdown review in this folder as well. No ppt/word/etc. yet please, we don't have a git LFS set up at the moment. 
+ - Push branch to your local fork and issue a pull request to the main repo
+ - Select reviewers for your merge request
+ - Loop as needed until merge request accepted
+
+##Instructions for committing reviews
+
+Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
+
+If you're committing a new content review see above, if you have comments or additions to already submitted reviews please consider the following. If you have commentary on a review of a proposed work and it has not yet been merged, chime in on the merge request
+
+If the review was already merged into main, review the instructions for committing new content. In the reviewer's folder of a paper, add another markdown file with your comments and add your name to the title of the file. Follow the branch/merge instructions. 
+

--- a/research-workstream/2024/2HC24/README.md
+++ b/research-workstream/2024/2HC24/README.md
@@ -1,7 +1,7 @@
-#Committing new content, reviewing, and browsing
+# Committing new content, reviewing, and browsing
 If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
 
-##Instructions for committing new content
+## Instructions for committing new content
 If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
  - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
  - Create a new branch 
@@ -13,7 +13,7 @@ If this is an active review window, and you are committing a review of a propose
  - Select reviewers for your merge request
  - Loop as needed until merge request accepted
 
-##Instructions for committing reviews
+## Instructions for committing reviews
 
 Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
 

--- a/research-workstream/2024/README.md
+++ b/research-workstream/2024/README.md
@@ -1,0 +1,5 @@
+#How to navigate this directory tree
+
+Each year reflects the review work of the CMS research workstream. In each directory there are review windows (e.g. xHCyy for now, we seem to be on a bi-annual cadence). In each review window there are another two folders, one for the selected work for the review window and another for the papers reviewed. 
+
+

--- a/research-workstream/2024/README.md
+++ b/research-workstream/2024/README.md
@@ -1,4 +1,4 @@
-#How to navigate this directory tree
+# How to navigate this directory tree
 
 Each year reflects the review work of the CMS research workstream. In each directory there are review windows (e.g. xHCyy for now, we seem to be on a bi-annual cadence). In each review window there are another two folders, one for the selected work for the review window and another for the papers reviewed. 
 

--- a/research-workstream/2025/1HC25/README.md
+++ b/research-workstream/2025/1HC25/README.md
@@ -1,0 +1,23 @@
+#Committing new content, reviewing, and browsing
+If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
+
+##Instructions for committing new content
+If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
+ - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
+ - Create a new branch 
+   - In the 'proposed' directory find your publication for review and create a folder with your name
+      - If the publication does not have a review folder, please create it using the title of the work. Use best judgement on length.
+   - Either add your .md review or create a markdown file and copy/paste your review into it. 
+   - upload any figures to be referenced by your markdown review in this folder as well. No ppt/word/etc. yet please, we don't have a git LFS set up at the moment. 
+ - Push branch to your local fork and issue a pull request to the main repo
+ - Select reviewers for your merge request
+ - Loop as needed until merge request accepted
+
+##Instructions for committing reviews
+
+Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
+
+If you're committing a new content review see above, if you have comments or additions to already submitted reviews please consider the following. If you have commentary on a review of a proposed work and it has not yet been merged, chime in on the merge request
+
+If the review was already merged into main, review the instructions for committing new content. In the reviewer's folder of a paper, add another markdown file with your comments and add your name to the title of the file. Follow the branch/merge instructions. 
+

--- a/research-workstream/2025/1HC25/README.md
+++ b/research-workstream/2025/1HC25/README.md
@@ -1,7 +1,7 @@
-#Committing new content, reviewing, and browsing
+# Committing new content, reviewing, and browsing
 If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
 
-##Instructions for committing new content
+## Instructions for committing new content
 If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
  - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
  - Create a new branch 
@@ -13,7 +13,7 @@ If this is an active review window, and you are committing a review of a propose
  - Select reviewers for your merge request
  - Loop as needed until merge request accepted
 
-##Instructions for committing reviews
+## Instructions for committing reviews
 
 Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
 

--- a/research-workstream/2025/2HC25/README.md
+++ b/research-workstream/2025/2HC25/README.md
@@ -1,0 +1,23 @@
+#Committing new content, reviewing, and browsing
+If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
+
+##Instructions for committing new content
+If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
+ - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
+ - Create a new branch 
+   - In the 'proposed' directory find your publication for review and create a folder with your name
+      - If the publication does not have a review folder, please create it using the title of the work. Use best judgement on length.
+   - Either add your .md review or create a markdown file and copy/paste your review into it. 
+   - upload any figures to be referenced by your markdown review in this folder as well. No ppt/word/etc. yet please, we don't have a git LFS set up at the moment. 
+ - Push branch to your local fork and issue a pull request to the main repo
+ - Select reviewers for your merge request
+ - Loop as needed until merge request accepted
+
+##Instructions for committing reviews
+
+Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
+
+If you're committing a new content review see above, if you have comments or additions to already submitted reviews please consider the following. If you have commentary on a review of a proposed work and it has not yet been merged, chime in on the merge request
+
+If the review was already merged into main, review the instructions for committing new content. In the reviewer's folder of a paper, add another markdown file with your comments and add your name to the title of the file. Follow the branch/merge instructions. 
+

--- a/research-workstream/2025/2HC25/README.md
+++ b/research-workstream/2025/2HC25/README.md
@@ -1,7 +1,7 @@
-#Committing new content, reviewing, and browsing
+# Committing new content, reviewing, and browsing
 If the review window is active, all content is likely in the proposed folder. If you're just browsing prior review windows, all selected works are in 'selected' and will also likely have additional content beyond the reviews (e.g. additional commentary from the original authors, links to recordings, etc.) but all works considered for the review window will be in the 'proposed' directory. 
 
-##Instructions for committing new content
+## Instructions for committing new content
 If this is an active review window, and you are committing a review of a proposed paper, please do the following. 
  - Fetch and merge latest, and if this is a local fork, please make sure you've fetched upstream to merge. 
  - Create a new branch 
@@ -13,7 +13,7 @@ If this is an active review window, and you are committing a review of a propose
  - Select reviewers for your merge request
  - Loop as needed until merge request accepted
 
-##Instructions for committing reviews
+## Instructions for committing reviews
 
 Make sure you've fetched latest before adding new content and if this is a local fork that your fork is also synced, please and thank you. 
 

--- a/research-workstream/2025/README.md
+++ b/research-workstream/2025/README.md
@@ -1,0 +1,5 @@
+#How to navigate this directory tree
+
+Each year reflects the review work of the CMS research workstream. In each directory there are review windows (e.g. xHCyy for now, we seem to be on a bi-annual cadence). In each review window there are another two folders, one for the selected work for the review window and another for the papers reviewed. 
+
+

--- a/research-workstream/2025/README.md
+++ b/research-workstream/2025/README.md
@@ -1,4 +1,4 @@
-#How to navigate this directory tree
+# How to navigate this directory tree
 
 Each year reflects the review work of the CMS research workstream. In each directory there are review windows (e.g. xHCyy for now, we seem to be on a bi-annual cadence). In each review window there are another two folders, one for the selected work for the review window and another for the papers reviewed. 
 

--- a/research-workstream/README.md
+++ b/research-workstream/README.md
@@ -1,0 +1,11 @@
+#CMS Academic/research workstream
+[insert group charter and contacts]
+
+
+##What's all this then?
+Every year the CMS academic workstream sets review-windows wherein research papers that are CXL or CXL adjacent are proposed for review by the group. 
+
+##How to navigate this directory tree
+Each year reflects the review work of the CMS research workstream. In each directory there are review windows (e.g. xHCyy for now, we seem to be on a bi-annual cadence). In each r
+eview window there are another two folders, one for the selected work for the review window and another for the papers reviewed.
+

--- a/research-workstream/README.md
+++ b/research-workstream/README.md
@@ -1,11 +1,14 @@
-#CMS Academic/research workstream
+# CMS Academic/research workstream
 [insert group charter and contacts]
 
 
-##What's all this then?
+## What's all this then?
 Every year the CMS academic workstream sets review-windows wherein research papers that are CXL or CXL adjacent are proposed for review by the group. 
 
-##How to navigate this directory tree
+## How to navigate this directory tree
 Each year reflects the review work of the CMS research workstream. In each directory there are review windows (e.g. xHCyy for now, we seem to be on a bi-annual cadence). In each r
 eview window there are another two folders, one for the selected work for the review window and another for the papers reviewed.
+
+## Tracking work and contributors
+There are a few tools we could use to do this, one is just the wiki that comes with github. TBD.
 


### PR DESCRIPTION
Hopefully fixed the "this commit wasn't signed" issue from previous attempt. Just sets up initial directory structure of the academic work stream folder in CMS and some readmes for how-to and what's up. 